### PR TITLE
Update IndexAndKeyProcessor.ts

### DIFF
--- a/src/IndexAndKeyProcessor.ts
+++ b/src/IndexAndKeyProcessor.ts
@@ -88,9 +88,6 @@ export default async (conversion: Conversion, tableName: string): Promise<void> 
             if (index_name.length > 63) {
                 // Postgres object names are truncated to 63 chars, and this can cause duplicate names
                 // This truncates the name to 57 chars and adds a 6 char UUID fragment, to make a unique name
-                // simon hewitt simon.hewitt@maplecroft.com Maplecroft
-                // Changed April 2022, to fix a problem with GRID MySL to Postgres migration
-                // (NB also submitted to the FOSS source)
                 const uuid_tag: string = uuid.v4()
                 index_name = index_name.substring(0, 57) + uuid_tag.substring(0,6)
                 console.log(index_name)


### PR DESCRIPTION
    Postgres limits all object names to 63 chars, nmig creates index names using:

    `${ conversion._schema }_${ tableName }_${ columnName }_idx`

    Eg `public_accounts_referrer_login_user_domain_id0_idx` where:

    * _public_ is the schema name
    * _accounts_referrerlogin_ is the table name
    * _user_domain_id_ is the column being indexed
    * __idx_ is fixed

This frequently exceeded 63 characters, and when this happens, Postgres simply truncates the name to 63 chars. Now in several cases, the 63 character truncated string was not unique, i.e. the `{ conversion._schema }_${ tableName }_` element was already 63 chars (or some compound indices sharing the same first column). This error showed as:

    `error: duplicate key value violates unique constraint "pg_class_relname_nsp_index"`
    i.e. a unique constraint on the index name itself.

    This change detects index names > 63 chars, and alters then by truncating the created index name to 53 chars then appendix a 6-char UUID fragment, giving a unique index name (very unlikely to have a clash on even 6 UUID chars for this limited use range)
